### PR TITLE
fix: empty list data may be possible for TopLevel

### DIFF
--- a/jsonapi_pydantic/v1_0/resource/resource.py
+++ b/jsonapi_pydantic/v1_0/resource/resource.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, Optional, Union, List
-
 from pydantic.config import ConfigDict
 from pydantic.fields import Field
 from pydantic.functional_validators import model_validator
 from pydantic.main import BaseModel
+from typing import Any, Dict, Optional, Union, List, Hashable
 
 from jsonapi_pydantic.v1_0.links import Links as LinksObject
 from jsonapi_pydantic.v1_0.meta import Meta as MetaObject
@@ -16,7 +15,7 @@ Links = Optional[LinksObject]
 Meta = Optional[MetaObject]
 
 
-class Resource(BaseModel):
+class Resource(BaseModel, Hashable):
     type: str = Field(title="Type")
     id: Id = Field(None, title="Id")
     attributes: Attributes = Field(None, title="Attributes")
@@ -25,6 +24,9 @@ class Resource(BaseModel):
     meta: Meta = Field(None, title="Meta")
 
     model_config = ConfigDict(frozen=True)
+
+    def __hash__(self) -> int:
+        return hash(self.type + self.id)
 
     @model_validator(mode="after")
     def check_all_values(self) -> "Resource":

--- a/jsonapi_pydantic/v1_0/resource/resource.py
+++ b/jsonapi_pydantic/v1_0/resource/resource.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union, List
 
 from pydantic.config import ConfigDict
 from pydantic.fields import Field
@@ -11,7 +11,7 @@ from jsonapi_pydantic.v1_0.resource.relationship import Relationship
 
 Id = Optional[str]
 Attributes = Optional[Dict[str, Any]]
-Relationships = Optional[Dict[str, Relationship]]
+Relationships = Optional[Dict[str, Union[Relationship, List[Relationship]]]]
 Links = Optional[LinksObject]
 Meta = Optional[MetaObject]
 

--- a/jsonapi_pydantic/v1_0/toplevel.py
+++ b/jsonapi_pydantic/v1_0/toplevel.py
@@ -38,7 +38,7 @@ class TopLevel(BaseModel):
     @model_validator(mode="before")
     def check_all_values(cls, data: dict) -> dict:
         # More about these restrictions: https://jsonapi.org/format/#document-top-level
-        if data.get("data") and data.get("errors"):
+        if data.get("data") is None and data.get("errors"):
             raise ValueError("The members data and errors MUST NOT coexist in the same document.")
         if data.get("included") and not data.get("data"):
             raise ValueError(


### PR DESCRIPTION
Empty list may be possible in data with no error.

In doc:
```
HTTP/1.1 200 OK
Content-Type: application/vnd.api+json

{
  "links": {
    "self": "http://example.com/articles"
  },
  "data": []
}
```

I  think also the data may be null without error but I didn't changed it as I think you may it intentionnaly :

```
HTTP/1.1 200 OK
Content-Type: application/vnd.api+json

{
  "links": {
    "self": "http://example.com/articles/1/author"
  },
  "data": null
}
```
 8.1.1.2 404 Not Found

A server MUST respond with 404 Not Found when processing a request to fetch a single resource that does not exist, except when the request warrants a 200 OK response with null as the primary data (as described above).