### PR TITLE
Resource made Hashable

### DIFF
--- a/examples/jsonapi/sparse_fieldsets.py
+++ b/examples/jsonapi/sparse_fieldsets.py
@@ -24,6 +24,7 @@ expected_data = {
     ],
 }
 
+assert expected_data == TopLevel(**expected_data), "Objects are not equal."
 
 data = [
     Resource(
@@ -42,6 +43,7 @@ included = [
     Resource(type="people", id="42", attributes={"name": "John", "age": 80, "gender": "male"})
 ]
 top_level = TopLevel(data=data, included=included)
+
 
 assert expected_data == top_level.model_dump(exclude_unset=True), "Objects are not equal."
 

--- a/jsonapi_pydantic/v1_0/resource/resource.py
+++ b/jsonapi_pydantic/v1_0/resource/resource.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Hashable
 
 from pydantic.config import ConfigDict
 from pydantic.fields import Field
@@ -16,7 +16,7 @@ Links = Optional[LinksObject]
 Meta = Optional[MetaObject]
 
 
-class Resource(BaseModel):
+class Resource(BaseModel, Hashable):
     type: str = Field(title="Type")
     id: Id = Field(None, title="Id")
     attributes: Attributes = Field(None, title="Attributes")
@@ -25,6 +25,9 @@ class Resource(BaseModel):
     meta: Meta = Field(None, title="Meta")
 
     model_config = ConfigDict(frozen=True)
+
+    def __hash__(self) -> int:
+        return hash(self.type + self.id)
 
     @model_validator(mode="after")
     def check_all_values(self) -> "Resource":

--- a/jsonapi_pydantic/v1_0/toplevel.py
+++ b/jsonapi_pydantic/v1_0/toplevel.py
@@ -1,4 +1,6 @@
-from typing import List, Optional, Union
+from typing import List
+from typing import Optional
+from typing import Union
 
 from pydantic.fields import Field
 from pydantic.functional_validators import model_validator
@@ -38,13 +40,13 @@ class TopLevel(BaseModel):
     @model_validator(mode="before")
     def check_all_values(cls, data: dict) -> dict:
         # More about these restrictions: https://jsonapi.org/format/#document-top-level
-        if data.get("data") and data.get("errors"):
+        if "data" in data and "errors" in data:
             raise ValueError("The members data and errors MUST NOT coexist in the same document.")
         if data.get("included") and not data.get("data"):
             raise ValueError(
                 "If a document does not contain a top-level data key, the included member MUST NOT be present either."
             )
-        if not data.get("data") and not data.get("errors") and not data.get("meta"):
+        if data.get("data") is None and not data.get("errors") and not data.get("meta"):
             raise ValueError(
                 "A document MUST contain at least one of the following top-level members: data, errors, meta."
             )


### PR DESCRIPTION
Make Resource hashable allows to manipulate them for Set (for constructing included resources for example).

It seems you have change from Set to List but I wonder why?

7.4
`A [compound document](https://jsonapi.org/format/#document-compound-documents) MUST NOT include more than one [resource object](https://jsonapi.org/format/#document-resource-objects) for each type and id pair.`